### PR TITLE
修复内存泄露、修复clickListener被重设情况

### DIFF
--- a/library/src/main/java/com/hjq/bar/TitleBar.java
+++ b/library/src/main/java/com/hjq/bar/TitleBar.java
@@ -248,15 +248,6 @@ public class TitleBar extends FrameLayout
     }
 
     @Override
-    protected void onAttachedToWindow() {
-        super.onAttachedToWindow();
-        // 设置监听
-        mTitleView.setOnClickListener(this);
-        mLeftView.setOnClickListener(this);
-        mRightView.setOnClickListener(this);
-    }
-
-    @Override
     protected void onDetachedFromWindow() {
         // 移除监听
         mTitleView.setOnClickListener(null);
@@ -277,6 +268,10 @@ public class TitleBar extends FrameLayout
      */
     public void setOnTitleBarListener(OnTitleBarListener l) {
         mListener = l;
+        // 设置监听
+        mTitleView.setOnClickListener(this);
+        mLeftView.setOnClickListener(this);
+        mRightView.setOnClickListener(this);
     }
 
     /**

--- a/library/src/main/java/com/hjq/bar/style/BaseTitleBarStyle.java
+++ b/library/src/main/java/com/hjq/bar/style/BaseTitleBarStyle.java
@@ -1,6 +1,7 @@
 package com.hjq.bar.style;
 
 import android.content.Context;
+import android.content.res.Resources;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
 
@@ -17,7 +18,7 @@ public abstract class BaseTitleBarStyle implements ITitleBarStyle {
     private Context mContext;
 
     public BaseTitleBarStyle(Context context) {
-        mContext = context;
+        mContext = context.getApplicationContext();
     }
 
     protected Context getContext() {
@@ -44,7 +45,7 @@ public abstract class BaseTitleBarStyle implements ITitleBarStyle {
      * dp转px
      */
     protected int dp2px(float dpValue) {
-        final float scale = getContext().getResources().getDisplayMetrics().density;
+        final float scale = Resources.getSystem().getDisplayMetrics().density;
         return (int) (dpValue * scale + 0.5f);
     }
 
@@ -52,7 +53,7 @@ public abstract class BaseTitleBarStyle implements ITitleBarStyle {
      * sp转px
      */
     protected int sp2px(float spValue) {
-        final float fontScale = getContext().getResources().getDisplayMetrics().scaledDensity;
+        final float fontScale = Resources.getSystem().getDisplayMetrics().scaledDensity;
         return (int) (spValue * fontScale + 0.5f);
     }
 


### PR DESCRIPTION
内存泄露情况说明:第一个activity没有使用TitleBar,跳转B，B有，结束B，会持有B的引用，引起内存泄露。
重设情况说明:我在setContentView之后拿到leftView进行设置clickListener，会被重新设置冲空的listener。